### PR TITLE
fix: mobile bounty view crash

### DIFF
--- a/frontend/app/src/people/main/body.tsx
+++ b/frontend/app/src/people/main/body.tsx
@@ -426,6 +426,8 @@ export default function BodyComponent({ selectedWidget }) {
         </div>
       ) : (
         <WidgetSwitchViewer
+          checkboxIdToSelectedMap={checkboxIdToSelectedMap}
+          checkboxIdToSelectedMapLanguage={checkboxIdToSelectedMapLanguage}
           onPanelClick={(person, item) => {
             history.replace({
               pathname: history?.location?.pathname,


### PR DESCRIPTION
on mobile view the bounties page was crashing because we merged changes and it seemed to not include these changes

## Describe your changes

## Issue ticket number and link

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have tested on Chrome and Firefox
- [ ] I have tested on a mobile device
- [ ] It has been deployed to people-test.sphinx.chat and tested by others
